### PR TITLE
skipping RP registration

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -31,6 +31,7 @@ provider "azurerm" {
       recover_soft_deleted_key_vaults = true
     }
   }
+  resource_provider_registrations = "none"
 }
 
 # Get current client configuration


### PR DESCRIPTION
This pull request makes a minor update to the Azure provider configuration in Terraform. The change sets the `resource_provider_registrations` property to `"none"` to control how resource providers are registered.