### PR TITLE
updated metric defs

### DIFF
--- a/terraform/modules/function-app/main.tf
+++ b/terraform/modules/function-app/main.tf
@@ -100,8 +100,38 @@ module "function_app" {
     default = {
       name                  = "diag-functionapp"
       workspace_resource_id = var.function_app_config.function_app.log_analytics_workspace_id
-      log_groups            = ["allLogs"]
-      metric_categories     = ["AllMetrics"]
+      enabled_log = [
+        {
+          category = "FunctionAppLogs"
+          retention_policy = {
+            enabled = false
+            days    = 0
+          }
+        },
+        {
+          category = "AppServiceAuditLogs"
+          retention_policy = {
+            enabled = false
+            days    = 0
+          }
+        },
+        {
+          category = "AppServiceHTTPLogs"
+          retention_policy = {
+            enabled = false
+            days    = 0
+          }
+        }
+      ]
+      enabled_metric = [
+        {
+          category = "AllMetrics"
+          retention_policy = {
+            enabled = false
+            days    = 0
+          }
+        }
+      ]
     }
   } : {}
 

--- a/terraform/modules/service-bus/main.tf
+++ b/terraform/modules/service-bus/main.tf
@@ -27,8 +27,24 @@ module "service_bus" {
     default = {
       name                  = "diag-servicebus"
       workspace_resource_id = var.service_bus_config.log_analytics_workspace_id
-      log_groups            = ["allLogs"]
-      metric_categories     = ["AllMetrics"]
+      enabled_log = [
+        {
+          category = "OperationalLogs"
+          retention_policy = {
+            enabled = false
+            days    = 0
+          }
+        }
+      ]
+      enabled_metric = [
+        {
+          category = "AllMetrics"
+          retention_policy = {
+            enabled = false
+            days    = 0
+          }
+        }
+      ]
     }
   } : {}
 

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -36,8 +36,38 @@ module "storage_account" {
     default = {
       name                  = "diag-storage"
       workspace_resource_id = var.storage_config.log_analytics_workspace_id
-      log_groups            = ["allLogs"]
-      metric_categories     = ["AllMetrics"]
+      enabled_log = [
+        {
+          category = "StorageRead"
+          retention_policy = {
+            enabled = false
+            days    = 0
+          }
+        },
+        {
+          category = "StorageWrite"
+          retention_policy = {
+            enabled = false
+            days    = 0
+          }
+        },
+        {
+          category = "StorageDelete"
+          retention_policy = {
+            enabled = false
+            days    = 0
+          }
+        }
+      ]
+      enabled_metric = [
+        {
+          category = "AllMetrics"
+          retention_policy = {
+            enabled = false
+            days    = 0
+          }
+        }
+      ]
     }
   } : {}
 


### PR DESCRIPTION
This pull request updates the diagnostic settings configuration for several Azure resources in the Terraform modules. The main change is replacing the older `log_groups` and `metric_categories` fields with more detailed `enabled_log` and `enabled_metric` blocks, allowing for more granular control over which logs and metrics are enabled and their retention policies.

**Diagnostic settings update:**

* Replaced `log_groups` and `metric_categories` with `enabled_log` and `enabled_metric` blocks for the function app, specifying categories such as `FunctionAppLogs`, `AppServiceAuditLogs`, and `AppServiceHTTPLogs`, each with retention policies set to disabled. (`terraform/modules/function-app/main.tf`)
* Updated the service bus module to use the new `enabled_log` (with `OperationalLogs`) and `enabled_metric` fields, also setting retention policies to disabled. (`terraform/modules/service-bus/main.tf`)
* Modified the storage account module to define explicit log categories (`StorageRead`, `StorageWrite`, `StorageDelete`) and metrics (`AllMetrics`) using the new configuration format, with retention disabled. (`terraform/modules/storage/main.tf`)