### PR TITLE
Feature/naming

### DIFF
--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -1,3 +1,5 @@
+# Resource Group Name (must already exist)
+resource_group_name = "<YOUR-DEV-RG-NAME>"
 # Development Environment Configuration
 
 # Environment Configuration

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -4,7 +4,7 @@ resource_group_name = "RG-JCI-INT-DEMO-DEV"
 
 # Environment Configuration
 environment = "dev"
-location    = "East US 2"
+location    = "eastus2"
 workload    = "azfuncjava"
 prefix      = ""
 suffix      = ""

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -1,5 +1,5 @@
 # Resource Group Name (must already exist)
-resource_group_name = "<YOUR-DEV-RG-NAME>"
+resource_group_name = "RG-JCI-INT-DEMO-DEV"
 # Development Environment Configuration
 
 # Environment Configuration

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -1,5 +1,5 @@
 # Resource Group Name (must already exist)
-resource_group_name = "<YOUR-PROD-RG-NAME>"
+resource_group_name = "RG-JCI-INT-DEMO-PRD"
 # Production Environment Configuration
 
 # Environment Configuration

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -1,3 +1,5 @@
+# Resource Group Name (must already exist)
+resource_group_name = "<YOUR-PROD-RG-NAME>"
 # Production Environment Configuration
 
 # Environment Configuration

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -3,8 +3,8 @@ resource_group_name = "RG-JCI-INT-DEMO-PRD"
 # Production Environment Configuration
 
 # Environment Configuration
-environment = "prod"
-location    = "East US 2"
+environment = "prd"
+location    = "eastus2"
 workload    = "azfuncjava"
 prefix      = ""
 suffix      = ""

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,16 +10,7 @@ module "naming" {
 }
 
 # Resource Group
-module "resource_group" {
-  source  = "Azure/avm-res-resources-resourcegroup/azurerm"
-  version = ">= 0.2.0"
 
-  name             = var.prefix != "" ? "${var.prefix}-${module.naming.resource_group.name}" : module.naming.resource_group.name
-  location         = var.location
-  enable_telemetry = var.enable_telemetry
-
-  tags = var.tags
-}
 
 # Monitoring Module (Log Analytics and Application Insights)
 module "monitoring" {
@@ -29,7 +20,7 @@ module "monitoring" {
     log_analytics = {
       name                = var.prefix != "" ? "${var.prefix}-${module.naming.log_analytics_workspace.name}" : module.naming.log_analytics_workspace.name
       location            = var.location
-      resource_group_name = module.resource_group.name
+      resource_group_name = var.resource_group_name
       enable_telemetry    = var.enable_telemetry
       retention_in_days   = var.monitoring_config.log_analytics.retention_in_days
       sku                 = var.monitoring_config.log_analytics.sku
@@ -39,7 +30,7 @@ module "monitoring" {
     application_insights = {
       name                          = var.prefix != "" ? "${var.prefix}-${module.naming.application_insights.name}" : module.naming.application_insights.name
       location                      = var.location
-      resource_group_name           = module.resource_group.name
+      resource_group_name           = var.resource_group_name
       enable_telemetry              = var.enable_telemetry
       application_type              = var.monitoring_config.application_insights.application_type
       retention_in_days             = var.monitoring_config.application_insights.retention_in_days
@@ -57,7 +48,7 @@ module "identity" {
   identity_config = {
     name                = var.prefix != "" ? "${var.prefix}-${module.naming.user_assigned_identity.name}" : module.naming.user_assigned_identity.name
     location            = var.location
-    resource_group_name = module.resource_group.name
+    resource_group_name = var.resource_group_name
     enable_telemetry    = var.enable_telemetry
     tags                = var.tags
 
@@ -76,7 +67,7 @@ module "storage" {
   storage_config = {
     name                          = var.prefix != "" ? "${var.prefix}${module.naming.storage_account.name_unique}" : module.naming.storage_account.name_unique
     location                      = var.location
-    resource_group_name           = module.resource_group.name
+    resource_group_name           = var.resource_group_name
     enable_telemetry              = var.enable_telemetry
     account_tier                  = var.storage_config.account_tier
     account_replication_type      = var.storage_config.account_replication_type
@@ -105,7 +96,7 @@ module "service_bus" {
   service_bus_config = {
     name                          = var.prefix != "" ? "${var.prefix}-${module.naming.servicebus_namespace.name}" : module.naming.servicebus_namespace.name
     location                      = var.location
-    resource_group_name           = module.resource_group.name
+    resource_group_name           = var.resource_group_name
     enable_telemetry              = var.service_bus_config.enable_telemetry
     sku                           = var.service_bus_config.sku
     capacity                      = var.service_bus_config.sku == "Premium" ? var.service_bus_config.capacity : null
@@ -133,7 +124,7 @@ module "function_app" {
     app_service_plan = {
       name                         = var.prefix != "" ? "${var.prefix}-${module.naming.app_service_plan.name}" : module.naming.app_service_plan.name
       location                     = var.location
-      resource_group_name          = module.resource_group.name
+      resource_group_name          = var.resource_group_name
       enable_telemetry             = var.enable_telemetry
       os_type                      = var.function_app_config.app_service_plan.os_type
       sku_name                     = var.function_app_config.app_service_plan.sku_name
@@ -147,7 +138,7 @@ module "function_app" {
     function_app = {
       name                                           = var.prefix != "" ? "${var.prefix}-${module.naming.function_app.name}" : module.naming.function_app.name
       location                                       = var.location
-      resource_group_name                            = module.resource_group.name
+      resource_group_name                            = var.resource_group_name
       enable_telemetry                               = var.enable_telemetry
       os_type                                        = var.function_app_config.function_app.os_type
       https_only                                     = var.function_app_config.function_app.https_only
@@ -159,7 +150,7 @@ module "function_app" {
       user_assigned_resource_ids = [module.identity.identity_resource_id]
 
       application_insights_name                = module.monitoring.application_insights.name
-      application_insights_resource_group_name = module.resource_group.name
+      application_insights_resource_group_name = var.resource_group_name
       application_insights_location            = var.location
       application_insights_type                = var.function_app_config.function_app.application_insights_type
       application_insights_workspace_id        = module.monitoring.log_analytics_id

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,8 +5,8 @@ module "naming" {
   source  = "Azure/naming/azurerm"
   version = ">= 0.4.0"
 
-  prefix = [var.workload, var.environment]
-  suffix = var.suffix != "" ? [var.suffix] : []
+  prefix = [var.workload]
+  suffix = [var.environment]
 }
 
 # Resource Group

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,8 @@
+# Resource Group Name (must be provided via environment variable)
+variable "resource_group_name" {
+  description = "Name of the existing Azure Resource Group to deploy resources into. Should be set via TF_VAR_resource_group_name, e.g., from AZURE_RESOURCE_GROUP_NAME."
+  type        = string
+}
 # Environment Configuration
 variable "environment" {
   description = "Environment name (dev, test, prod)"


### PR DESCRIPTION
This pull request refactors how resource group names are handled in the Terraform configuration. Instead of creating or deriving resource groups within the modules, the configuration now expects an existing resource group name to be provided explicitly. This change improves flexibility for deployments into pre-existing infrastructure and standardizes environment naming conventions.

**Resource Group Handling and Variable Management:**

* Added a new required variable `resource_group_name` in `variables.tf` and updated all relevant modules to use this variable instead of referencing a resource group module. This ensures all resources are deployed into an explicitly specified, pre-existing resource group. [[1]](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R1-R5) [[2]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L32-R23) [[3]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L42-R33) [[4]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L60-R51) [[5]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L79-R70) [[6]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L108-R99) [[7]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L136-R127) [[8]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L150-R141) [[9]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L162-R153)

* Updated environment-specific variable files (`dev/terraform.tfvars`, `prod/terraform.tfvars`) to include the new `resource_group_name` variable with appropriate values for each environment. [[1]](diffhunk://#diff-c254139c46d96fcb4fb6d642699d37ddc74537f4f6838a009b943e6dd3abb6afR1-R7) [[2]](diffhunk://#diff-b93125e26c6f884a6b58d56821c352ee88a08da69c06adcd891cc813e7a0d6dbR1-R7)

**Naming and Environment Convention Updates:**

* Modified the naming module's usage so that only the workload is used as the prefix and the environment as the suffix, simplifying and standardizing naming conventions.

* Changed the `environment` value in production from `prod` to `prd` and standardized the `location` values to lowercase (e.g., `eastus2`) for consistency. [[1]](diffhunk://#diff-c254139c46d96fcb4fb6d642699d37ddc74537f4f6838a009b943e6dd3abb6afR1-R7) [[2]](diffhunk://#diff-b93125e26c6f884a6b58d56821c352ee88a08da69c06adcd891cc813e7a0d6dbR1-R7)

**Module Cleanup:**

* Removed the `resource_group` module block from `main.tf`, as resource groups are now expected to be managed outside of this configuration.

These changes collectively improve deployment flexibility, enforce naming consistency, and clarify resource group management in the Terraform codebase.