### PR TITLE
fixing danging rg reference

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,7 @@
+# Data source for existing resource group
+data "azurerm_resource_group" "rg" {
+  name = var.resource_group_name
+}
 # Main Terraform configuration for Azure Functions Java Demo Infrastructure
 
 # Azure Naming Module for consistent resource naming
@@ -20,7 +24,7 @@ module "monitoring" {
     log_analytics = {
       name                = var.prefix != "" ? "${var.prefix}-${module.naming.log_analytics_workspace.name}" : module.naming.log_analytics_workspace.name
       location            = var.location
-      resource_group_name = var.resource_group_name
+  resource_group_name = data.azurerm_resource_group.rg.name
       enable_telemetry    = var.enable_telemetry
       retention_in_days   = var.monitoring_config.log_analytics.retention_in_days
       sku                 = var.monitoring_config.log_analytics.sku
@@ -30,7 +34,7 @@ module "monitoring" {
     application_insights = {
       name                          = var.prefix != "" ? "${var.prefix}-${module.naming.application_insights.name}" : module.naming.application_insights.name
       location                      = var.location
-      resource_group_name           = var.resource_group_name
+  resource_group_name           = data.azurerm_resource_group.rg.name
       enable_telemetry              = var.enable_telemetry
       application_type              = var.monitoring_config.application_insights.application_type
       retention_in_days             = var.monitoring_config.application_insights.retention_in_days
@@ -48,7 +52,7 @@ module "identity" {
   identity_config = {
     name                = var.prefix != "" ? "${var.prefix}-${module.naming.user_assigned_identity.name}" : module.naming.user_assigned_identity.name
     location            = var.location
-    resource_group_name = var.resource_group_name
+  resource_group_name = data.azurerm_resource_group.rg.name
     enable_telemetry    = var.enable_telemetry
     tags                = var.tags
 
@@ -67,7 +71,7 @@ module "storage" {
   storage_config = {
     name                          = var.prefix != "" ? "${var.prefix}${module.naming.storage_account.name_unique}" : module.naming.storage_account.name_unique
     location                      = var.location
-    resource_group_name           = var.resource_group_name
+  resource_group_name           = data.azurerm_resource_group.rg.name
     enable_telemetry              = var.enable_telemetry
     account_tier                  = var.storage_config.account_tier
     account_replication_type      = var.storage_config.account_replication_type
@@ -96,7 +100,7 @@ module "service_bus" {
   service_bus_config = {
     name                          = var.prefix != "" ? "${var.prefix}-${module.naming.servicebus_namespace.name}" : module.naming.servicebus_namespace.name
     location                      = var.location
-    resource_group_name           = var.resource_group_name
+  resource_group_name           = data.azurerm_resource_group.rg.name
     enable_telemetry              = var.service_bus_config.enable_telemetry
     sku                           = var.service_bus_config.sku
     capacity                      = var.service_bus_config.sku == "Premium" ? var.service_bus_config.capacity : null
@@ -124,7 +128,7 @@ module "function_app" {
     app_service_plan = {
       name                         = var.prefix != "" ? "${var.prefix}-${module.naming.app_service_plan.name}" : module.naming.app_service_plan.name
       location                     = var.location
-      resource_group_name          = var.resource_group_name
+  resource_group_name          = data.azurerm_resource_group.rg.name
       enable_telemetry             = var.enable_telemetry
       os_type                      = var.function_app_config.app_service_plan.os_type
       sku_name                     = var.function_app_config.app_service_plan.sku_name
@@ -138,7 +142,7 @@ module "function_app" {
     function_app = {
       name                                           = var.prefix != "" ? "${var.prefix}-${module.naming.function_app.name}" : module.naming.function_app.name
       location                                       = var.location
-      resource_group_name                            = var.resource_group_name
+  resource_group_name                            = data.azurerm_resource_group.rg.name
       enable_telemetry                               = var.enable_telemetry
       os_type                                        = var.function_app_config.function_app.os_type
       https_only                                     = var.function_app_config.function_app.https_only
@@ -150,7 +154,7 @@ module "function_app" {
       user_assigned_resource_ids = [module.identity.identity_resource_id]
 
       application_insights_name                = module.monitoring.application_insights.name
-      application_insights_resource_group_name = var.resource_group_name
+  application_insights_resource_group_name = data.azurerm_resource_group.rg.name
       application_insights_location            = var.location
       application_insights_type                = var.function_app_config.function_app.application_insights_type
       application_insights_workspace_id        = module.monitoring.log_analytics_id

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,12 +3,12 @@
 # Resource Group
 output "resource_group_name" {
   description = "Name of the resource group"
-  value       = module.resource_group.name
+  value       = data.azurerm_resource_group.rg.name
 }
 
 output "resource_group_id" {
   description = "ID of the resource group"
-  value       = module.resource_group.resource_id
+  value       = data.azurerm_resource_group.rg.id
 }
 
 # Function App


### PR DESCRIPTION
This pull request updates the Terraform configuration to reference an existing Azure resource group using a data source, rather than creating or directly referencing it via input variables. The change ensures all modules consistently use the resolved resource group details, improving reliability and maintainability when deploying into pre-existing infrastructure.

**Resource Group Reference Updates:**

* Added a `data "azurerm_resource_group"` block in `main.tf` to fetch details of an existing resource group using the `var.resource_group_name` variable.
* Updated all module blocks (`monitoring`, `identity`, `storage`, `service_bus`, `function_app`) in `main.tf` to use `data.azurerm_resource_group.rg.name` instead of `var.resource_group_name` for the `resource_group_name` property. [[1]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L23-R27) [[2]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L33-R37) [[3]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L51-R55) [[4]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L70-R74) [[5]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L99-R103) [[6]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L127-R131) [[7]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L141-R145) [[8]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L153-R157)

**Outputs Consistency:**

* Updated `outputs.tf` to reference the data source (`data.azurerm_resource_group.rg.name` and `data.azurerm_resource_group.rg.id`) for the resource group outputs instead of the `module.resource_group`.