### PR TITLE
errrggghhh

### DIFF
--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -140,7 +140,7 @@ function_app_config = {
     site_config = {
       java_version        = "11"
       # always_on is only for Premium plans, not used for Consumption
-      # always_on           = true
+      always_on           = false
       http2_enabled       = true
       minimum_tls_version = "1.2"
       ftps_state          = "Disabled"


### PR DESCRIPTION
This pull request makes a minor configuration adjustment to the Azure Function App settings in the production environment. The change sets the `always_on` property to `false` in the `site_config` block, which is appropriate for Consumption plans.